### PR TITLE
Rename the 'Setting' menu item to 'Settings'

### DIFF
--- a/app/views/menus/MainMenu.js
+++ b/app/views/menus/MainMenu.js
@@ -75,7 +75,7 @@ MainMenu.prototype.setup = function () {
     this.separator();
     this.register({
         key: "settingAllCommand",
-        label: "Setting...",
+        label: "Settings...",
         icon: "settings",
         isValid: function () { return true; },
         run: function () {

--- a/app/views/tools/SettingDialog.js
+++ b/app/views/tools/SettingDialog.js
@@ -1,6 +1,6 @@
 function SettingDialog() {
     Dialog.call(this);
-    this.title = "Setting Dialog";
+    this.title = "Settings";
 
     this.configElements = {
         "grid.enabled": this.checkboxEnableGrid,


### PR DESCRIPTION
I also made the corresponding change to the dialog title and removed the word "Dialog" for consistency with the other dialogs in that directory.