### PR TITLE
Set canvas size convenient for PDF / SVG export.

### DIFF
--- a/app/pencil-core/common/controller.js
+++ b/app/pencil-core/common/controller.js
@@ -1299,6 +1299,25 @@ Controller.prototype.getBestFitSize = function () {
     return this.applicationPane.getBestFitSize();
 };
 
+Controller.prototype.sizeToWidthHeight = function (passedPage, width, height) {
+    var page = passedPage ? passedPage : this.activePage;
+    var canvas = page.canvas;
+    if (!canvas) return;
+    if (canvas.zoom != 1) {
+        canvas.zoomTo(1);
+    }
+    width = parseInt(width);
+    height = parseInt(height);
+    if (width && height) {
+        canvas.setSize(width, height);
+        page.width = width;
+        page.height = height;
+        Config.set("lastSize", [width, height].join("x"));
+        this.invalidateBitmapFilePath(page);
+        this.sayDocumentChanged();
+    }
+};
+
 Controller.prototype.handleCanvasModified = function (canvas) {
     if (!canvas || !canvas.page) return;
     this.modified = true;

--- a/app/views/menus/CanvasMenu.js
+++ b/app/views/menus/CanvasMenu.js
@@ -213,6 +213,13 @@ CanvasMenu.prototype.setup = function () {
         }
     });
     UICommandManager.register({
+      key: "fitExportCommand",
+        label: "Fit SVG/PDF Export (744x1052)",
+        run: function () {
+            Pencil.controller.sizeToWidthHeight(null, 744, 1052); // FIXME: bug
+        }
+    });
+    UICommandManager.register({
       key: "sizingPolicyCommand",
         label: "Sizing Policy...",
         isAvailable: function () {
@@ -282,9 +289,12 @@ CanvasMenu.prototype.setup = function () {
     this.register({
         label: "Resize Canvas",
         type: "SubMenu",
-        subItems: [UICommandManager.getCommand("fitContentCommand"),
-                    UICommandManager.getCommand("fitContentwithPaddingCommand"),
-                    UICommandManager.getCommand("fitScreenCommand")]
+        subItems: [
+            UICommandManager.getCommand("fitContentCommand"),
+            UICommandManager.getCommand("fitContentwithPaddingCommand"),
+            UICommandManager.getCommand("fitScreenCommand"),
+            UICommandManager.getCommand("fitExportCommand")
+        ]
     });
 
     this.separator();


### PR DESCRIPTION
When exporting into pdf of svg the canvas in the export will be set to
something like 744x1052 (probably taken from svg tag attributes in file
`app/pencil-core/exporter/Pencil2SVG.xslt` line 43, cf.
https://github.com/evolus/pencil/issues/213).

This change adds an option in the canvas (resize) menu to resize the canvas
to this size.