### PR TITLE
SVG rendering now works

### DIFF
--- a/app/pencil-core/exporter/Pencil2SVG.xslt
+++ b/app/pencil-core/exporter/Pencil2SVG.xslt
@@ -36,18 +36,19 @@
     xmlns:em="http://exslt.org/math"
     xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
     xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape">
-    
+
     <xsl:output method="xml"/>
 
     <xsl:template match="/">
-        <svg width="744.09448819" height="1052.3622047"
+        <svg width="{/p:Document/p:Pages/p:Page/p:Properties/p:Property[@name='width']/text()}"
+            height="{/p:Document/p:Pages/p:Page/p:Properties/p:Property[@name='height']/text()}"
             id="exportedSVG"
             version="1.1"
             pencil:version="1.2.2"
             sodipodi:docname="{/p:Document/p:Properties/p:Property[@name='fileName']/text()}">
-            
+
             <xsl:apply-templates select="/p:Document/p:Pages/p:Page" />
-            
+
         </svg>
     </xsl:template>
     <xsl:template match="p:Page">


### PR DESCRIPTION
solves #183

the correct width/height information had to be added to the svg meta data too

tested it on my local clone, Windows 10, 64 bit and it worked indeed

[sorry for the blank line commits, my editor did this but I think it is not crucial hence I let them there]