### PR TITLE
Add option to show grid as solid lines vs dots

### DIFF
--- a/app/pencil-core/canvasHelper/canvasImpl.js
+++ b/app/pencil-core/canvasHelper/canvasImpl.js
@@ -15,6 +15,7 @@ CanvasImpl.setupGrid = function () {
     }
     if (Config.get("grid.enabled")) {
         var grid = Pencil.getGridSize();
+        var gridStyle = Pencil.getGridStyle();
         if (grid.w > 0 && grid.h > 0) {
             var z = this.zoom ? this.zoom : 1;
             for (var i = 1; i < this.width * z; i += grid.w * z) {
@@ -23,8 +24,20 @@ CanvasImpl.setupGrid = function () {
                 line.setAttribute("y1", 0);
                 line.setAttribute("x2", i);
                 line.setAttribute("y2", this.height * z);
-                line.setAttribute("style", "stroke-dasharray: 1," + (grid.h - 1) * z + ";");
+                if (gridStyle === "Dotted") {
+                   line.setAttribute("style", "stroke-dasharray: 1," + (grid.h - 1) * z + ";");
+                }
                 this.gridContainer.appendChild(line);
+            }
+            if (gridStyle === "Solid") {
+               for (var i = 1; i < this.height * z; i += grid.h * z) {
+                  var line = document.createElementNS(PencilNamespaces.svg, "svg:line");
+                  line.setAttribute("x1", 0);
+                  line.setAttribute("y1", i);
+                  line.setAttribute("x2", this.width * z);
+                  line.setAttribute("y2", i);
+                  this.gridContainer.appendChild(line);
+               }
             }
         }
     }

--- a/app/pencil-core/common/Canvas.js
+++ b/app/pencil-core/common/Canvas.js
@@ -334,7 +334,7 @@ function Canvas(element) {
 
     this.setupEventHandlers();
     window.globalEventBus.listen("config-change", function (data) {
-        if (["grid.enabled", "edit.gridSize"].indexOf(data.name) >= 0) {
+        if (["grid.enabled", "edit.gridSize", "edit.gridStyle"].indexOf(data.name) >= 0) {
             CanvasImpl.setupGrid.apply(this);
         }
     }.bind(this));

--- a/app/pencil-core/common/pencil.js
+++ b/app/pencil-core/common/pencil.js
@@ -509,6 +509,15 @@ Pencil.getGridSize = function () {
     return {w: size, h: size};
 };
 
+Pencil.getGridStyle = function () {
+    var style = Config.get("edit.gridStyle");
+    if (style == null) {
+        style = "Dotted";
+        Config.set("edit.gridStyle", style);
+    }
+    return style;
+};
+
 Pencil.getCurrentTarget = function () {
     var canvas = Pencil.activeCanvas;
     return canvas ? canvas.currentController : null;

--- a/app/views/tools/SettingDialog.js
+++ b/app/views/tools/SettingDialog.js
@@ -5,6 +5,7 @@ function SettingDialog() {
     this.configElements = {
         "grid.enabled": this.checkboxEnableGrid,
         "edit.gridSize" : this.textboxGridSize,
+        "edit.gridStyle" : this.comboGridStyle,
         "edit.snap.grid": this.snapToGrid,
         "object.snapping.enabled": this.enableSnapping,
         "object.snapping.background": this.enableSnappingBackground,
@@ -79,6 +80,12 @@ function SettingDialog() {
         this.setPreferenceItems();
     }, this.preferenceNameInput);
 
+    var thiz = this;
+    this.comboGridStyle.addEventListener("p:ItemSelected", function (event) {
+        var gridStyle = thiz.comboGridStyle.getSelectedItem();
+        thiz.updateConfigAndInvalidateUI("edit.gridStyle", gridStyle);
+    }, false);
+
 }
 __extend(Dialog, SettingDialog);
 
@@ -89,8 +96,10 @@ SettingDialog.prototype.updateConfigAndInvalidateUI = function (configName, valu
         if (checkBox == this.checkboxEnableGrid) {
             if (value) {
                 Dom.removeClass(this.textboxGridSize.parentNode, "Disabled");
+                Dom.removeClass(this.gridStyleContainer, "Disabled");
             } else {
                 Dom.addClass(this.textboxGridSize.parentNode, "Disabled");
+                Dom.addClass(this.gridStyleContainer, "Disabled");
             }
         }
         if (checkBox == this.undoEnabled) {
@@ -130,6 +139,13 @@ SettingDialog.prototype.setup = function () {
     }
     this.textboxGridSize.value = Config.get("edit.gridSize");
 
+    this.comboGridStyle.setItems(["Dotted", "Solid"]);
+    var gridStyle = Config.get("edit.gridStyle");
+    if (gridStyle == null) {
+       Config.set("edit.gridStyle", "Dotted");
+    }
+    this.comboGridStyle.selectItem(gridStyle);
+
     // var w = Config.get("clipartbrowser.scale.width");
     // var h = Config.get("clipartbrowser.scale.height");
     // if (w == null) {
@@ -162,8 +178,10 @@ SettingDialog.prototype.setup = function () {
 
     if (this.checkboxEnableGrid.checked) {
         Dom.removeClass(this.textboxGridSize.parentNode, "Disabled");
+        Dom.removeClass(this.gridStyleContainer, "Disabled");
     } else {
         Dom.addClass(this.textboxGridSize.parentNode, "Disabled");
+        Dom.addClass(this.gridStyleContainer, "Disabled");
     }
 
     if (this.undoEnabled.checked) {
@@ -241,6 +259,13 @@ SettingDialog.prototype.initializePreferenceTable = function () {
                                     result = "/usr/bin/inkscape";
                                 }
                                 thiz.svgEditorUrl.value = result;
+                            }
+                            if (data.name == "edit.gridStyle")
+                            {
+                               if (result == "") {
+                                  result = "Dotted"
+                               }
+                               thiz.comboGridStyle.selectedItem = result;
                             }
                         }
                         Config.set(data.name, result);

--- a/app/views/tools/SettingDialog.xhtml
+++ b/app/views/tools/SettingDialog.xhtml
@@ -78,6 +78,10 @@
                             <label>Grid size:</label>
                             <input anon-id="textboxGridSize" size="1" type="number" min="1" max="256" preference="pencil-gridSize" configName="edit.gridSize" default-value="5"/>
                         </hbox>
+                        <hbox anon-id="gridStyleContainer" class="Entry Disabled">
+                           <label>Grid style:</label>
+                           <ui:ComboManager anon-id="comboGridStyle" title="Grid style" />
+                        </hbox>
                     </hbox>
                     <hbox class="Entry">
                         <input type="checkbox" anon-id="snapToGrid" label="Show grid" preference="pencil-snapToGrid" configName="edit.snap.grid"/>


### PR DESCRIPTION
Although the dotted grid is subtle and unobtrusive, sometimes it can be extremely helpful to have a solid-line grid instead. This pull request adds an option to select the use of solid lines vs dots for the grid.

This is my first time digging into this code, so if I have done something wrong or not quite right, please don't hesitate to ask for changes to this pull request before accepting it.

Thanks!