### PR TITLE
Added functionality to change the default Private Stencil repository for sharing purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ Linux
     * Ubuntu 12.04 and later
     * Fedora 21+
     * Debian 8+
+
+Sharing Stencils with a Team
+==================
+To use team's Private Stencils just configure the folder for the PrivateCollection.xml file at *Settings > Advanced* and set the value of *shared.privateStencils.path*.
+
+You can use for exemple a versioned network directory for sharing.

--- a/app/pencil-core/common/config.js
+++ b/app/pencil-core/common/config.js
@@ -11,6 +11,14 @@ Config.getDataPath = function () {
     return path.join(os.homedir(), Config.DATA_DIR_NAME);
 };
 
+Config.getPrivateStencilsFilePath = function () {
+    var sharedPath = Config.get("shared.privateStencils.path");
+
+    return (sharedPath && sharedPath !== "")
+        ? sharedPath
+        : Config.getDataFilePath(Config.PRIVATE_STENCILS_DIR_NAME);
+};
+
 Config.getDataFilePath = function (name) {
     return path.join(Config.getDataPath(), name);
 };

--- a/app/pencil-core/privateCollection/privateCollectionManager.js
+++ b/app/pencil-core/privateCollection/privateCollectionManager.js
@@ -4,6 +4,10 @@ PrivateCollectionManager.privateShapeDef = {};
 PrivateCollectionManager.privateShapeDef.shapeDefMap = {};
 PrivateCollectionManager.privateShapeDef.collections = [];
 
+if (!Config.get("shared.privateStencils.path")) {
+    Config.set("shared.privateStencils.path", "");
+}
+
 PrivateCollectionManager.loadPrivateCollections = function () {
 
     try {
@@ -81,7 +85,7 @@ PrivateCollectionManager.getPrivateCollectionFile = function () {
     return path.join(PrivateCollectionManager.getPrivateCollectionDirectory(), "PrivateCollection.xml");
 };
 PrivateCollectionManager.getPrivateCollectionDirectory = function () {
-    return Config.getDataFilePath(Config.PRIVATE_STENCILS_DIR_NAME);
+    return Config.getPrivateStencilsFilePath();
 };
 
 PrivateCollectionManager.locateShapeDefinition = function (defId) {

--- a/app/views/tools/SettingDialog.js
+++ b/app/views/tools/SettingDialog.js
@@ -234,6 +234,7 @@ SettingDialog.prototype.initializePreferenceTable = function () {
                     Dialog.prompt(data.name, data.value, "OK", function (value) {
                         data.value = value;
                         var result = value;
+                        var oldValue = Config.get(data.name);
                         if (data.type != "string") {
                             result = parseInt(value);
                             if (data.name == "view.undoLevel" || data.name == "edit.gridSize" ) {
@@ -271,6 +272,10 @@ SettingDialog.prototype.initializePreferenceTable = function () {
                         }
                         Config.set(data.name, result);
                         thiz.setPreferenceItems();
+
+                        if (data.name == "shared.privateStencils.path" && value != oldValue) {
+                            Pencil.app.mainWindow.reload()
+                        }
                     }, "Cancel");
                 }
             }


### PR DESCRIPTION
Just set the value of the variable shared.privateStencils.path in Settings > Advanced.
If no value is setted, it will use the default value.