### PR TITLE
Fixed typo

### DIFF
--- a/app/views/editors/TextToolOverlay.xhtml
+++ b/app/views/editors/TextToolOverlay.xhtml
@@ -77,7 +77,7 @@
                     <button anon-id="mtextColorButton" title="Text Color">
                         <i>format_color_text</i>
                     </button>
-                    <button anon-id="mhilightColorButton" title="Hilight color">
+                    <button anon-id="mhilightColorButton" title="Highlight color">
                         <i>high_quality</i>
                         <!-- <span anon-id="colorDisplay" class="ColorDisplay"></span> -->
                     </button>


### PR DESCRIPTION
Love the app!

Was just using it quickly and noticed this typo.  "Hilight" -> "Highlight".  