### PR TITLE
Poor fix for FileHandler

### DIFF
--- a/app/pencil-core/common/FileHandler.js
+++ b/app/pencil-core/common/FileHandler.js
@@ -89,8 +89,12 @@ FileHandler.prototype.parseDocument = function (filePath, callback) {
 
             if (page.parentPageId) {
                 var parentPage = this.controller.findPageById(page.parentPageId);
-                page.parentPage = parentPage;
-                parentPage.children.push(page);
+                if(parentPage){
+                    page.parentPage = parentPage;
+                    parentPage.children.push(page);
+                } else {
+                    delete page.parentPageId;
+                }
             }
         }, thiz);
 


### PR DESCRIPTION
Fixes crash when opening epgz. I encountered issues when opening a pencil project file (really similar to #272 and #301). I suppose this happens when you move around the hierarchy of the pages. For instance when removing a page's root. This is a really poor fix because it doesn't fix the root of the issue, it just avoids the exception in order to open the file. This PR is here to draw the attention on the code that caused problems in my case.

