### PR TITLE
Fix Electron's Windows Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "Pencil",
+  "author": {
+    "name": "Evolus"
+  },
+  "description": "An open-source GUI prototyping tool that is available for ALL platforms.",
   "devDependencies": {
     "electron": "6.0.1",
     "electron-builder": "20.28.4",
@@ -29,7 +33,6 @@
       ]
     },
     "linux": {
-      "description": "An open-source GUI prototyping tool that is available for ALL platforms.",
       "synopsis": "An open-source GUI prototyping tool that is available for ALL platforms.",
       "maintainer": "Nguyen Tien Dzung <ngtdungnt@gmail.com>",
       "vendor": "Evolus",
@@ -43,11 +46,7 @@
       "packageCategory": "graphics"
     },
     "win": {
-      "authors": "Evolus",
-      "owners": "Evolus",
-      "description": "An open-source GUI prototyping tool that is available for ALL platforms.",
-      "copyright": "Copyright © 2008-2016 Evolus. All rights reserved.",
-      "iconUrl": "https://raw.githubusercontent.com/evolus/pencil/master/build/icon.ico",
+      "icon": "build/icon.ico",
       "target": "nsis"
     },
     "nsis": {


### PR DESCRIPTION
The "win" key for electron configuration in the package.json file
contains outdated keys, which results in an error when building a
release with electron-builder.

These changes fix the issue by moving the description & author fields
into top-level keys, changing the iconUrl key to icon, and removing
the unsupported owners & copyright fields.

You can see the available `"win"` config options here:
https://www.electron.build/configuration/win