### PR TITLE
Fix undefined path when unlinking bitmap

### DIFF
--- a/app/pencil-core/common/controller.js
+++ b/app/pencil-core/common/controller.js
@@ -1421,7 +1421,7 @@ Controller.prototype.invalidateBitmapFilePath = function (page, invalidatedIds) 
         for (var key in page.bitmapCache) {
             var filePath = page.bitmapCache[key];
             try {
-                fs.unlinkSync(page.bitmapFilePath);
+                fs.unlinkSync(filePath);
             } catch (e) {
             }
         }


### PR DESCRIPTION
I found this because pencil always got stuck when opening a file or creating a new one. It looks like someone forgot to change this line a long time ago (6110fdbdc961767e584e9e64a82925c153221590).

I'm not exactly sure why, but after I changed it everything worked fine again, so I hope this makes pencil a bit more stable.