### PR TITLE
Fix error during save if document contains font which is not installed locally

### DIFF
--- a/app/pencil-core/common/FontLoader.js
+++ b/app/pencil-core/common/FontLoader.js
@@ -151,7 +151,7 @@ FontLoader.prototype.embedToDocumentRepo = function (faces) {
         var font = this.userRepo.getFont(f);
         var userFont = this.documentRepo.getFont(f);
         if (userFont) {
-            if (!font.autoEmbed) {
+            if (font && !font.autoEmbed) {
                 this.documentRepo.removeFont(userFont);
             }
             return;


### PR DESCRIPTION
If a document contains a font which is not locally installed and embedding this font is disabled, Pencil simply hangs during save.

The reason seems to be a typo in the FontLoader code where it checks `font.autoEmbed` (even if font is null) instead of `userFont`.

This pull request fixes that typo and makes save work again for me.