### PR TITLE
Changed key modifiers to match Adobe Products

### DIFF
--- a/app/pencil-core/common/Canvas.js
+++ b/app/pencil-core/common/Canvas.js
@@ -2215,7 +2215,7 @@ Canvas.prototype.handleMouseDown = function (event) {
             break;
         }
     }
-    if (event.shiftKey) {
+    if (event.altKey) {
         if (!foundTarget && top) {
             thiz.clearSelection();
             thiz.addToSelection(thiz.createControllerFor(top));
@@ -2357,7 +2357,7 @@ Canvas.prototype.handleMouseDown = function (event) {
 };
 
 Canvas.prototype.isEventWithControl = function (event) {
-    return (event.ctrlKey && !IS_MAC) || (event.metaKey && IS_MAC);
+    return event.shiftKey;
 };
 Canvas.prototype.doGroup = function () {
 


### PR DESCRIPTION
Major design software like Adobe products and Balsamiq use **ALT + DRAG** to copy an item and **SHIFT + CLICK** for multiple selections.
Pencil key binding for some reason are different and for many people coming from major design software this key setup is confusing thus I changed it to match other major design software.