### PR TITLE
fixes the calculation of alignment for dynamic width shapes

### DIFF
--- a/app/stencils/Common/Definition.xml
+++ b/app/stencils/Common/Definition.xml
@@ -195,7 +195,7 @@
             <For ref="text">
                 <Fill>$textColor</Fill>
                 <Font>$textFont</Font>
-                <DomContent>F.buildTextWrapDomContent(F._target, $label.value, $fixedWidth.value ? $width.x : 2000, $textAlign)</DomContent>
+                <DomContent>F.buildTextWrapDomContent(F._target, $label.value, $fixedWidth.value ? $width.x : 2000, $textAlign, true)</DomContent>
             </For>
             <For ref="bgRect">
                 <Visibility>$fixedWidth</Visibility>


### PR DESCRIPTION
This change aims to fix the behaviour of alignment for plain text type shapes (label, text box, box, etc). Previously the width for these was hardcoded at 2000 which means center and right alignment would cause the content to 'disappear' off the visible canvas.

This change allows types to define dynamic width so that alignment is calculated with respect to the longest line of content or container width, whichever is first.

See a video here for test cases and explanation: https://www.loom.com/share/db04a47c71124cf5a6d42e402f68dabc