### PR TITLE
feat: use XDG base directories via `app.getPath("userData")`, closes #174

### DIFF
--- a/app/pencil-core/common/config.js
+++ b/app/pencil-core/common/config.js
@@ -1,14 +1,19 @@
+const { app } = require("@electron/remote");
+
 var Config = {
 };
 
 Config.data = {};
-Config.DATA_DIR_NAME = ".pencil";
 Config.STENCILS_DIR_NAME = "stencils";
 Config.PRIVATE_STENCILS_DIR_NAME = "privateCollection";
 Config.CONFIG_FILE_NAME = "config.json";
 
 Config.getDataPath = function () {
-    return path.join(os.homedir(), Config.DATA_DIR_NAME);
+    const homeDataDir = path.join(os.homedir(), ".pencil");
+    if (fs.existsSync(homeDataDir)) {
+        return homeDataDir;
+    }
+    return app.getPath("userData");
 };
 
 Config.getDataFilePath = function (name) {


### PR DESCRIPTION
For backwards compatibility, this first checks if the current config directory `~/.pencil/` exists. If it does, it uses that.

Otherwise it uses `~/.config/Pencil/`. In fact this directory also already exists. I'm not sure why *Pencil* has 2 config directories. This PR then reduces the # of config directories to 1.

I tested this on the current release v3.1.1.