### PR TITLE
Security: DOM XSS via unsanitized `innerHTML` assignment

### DIFF
--- a/app/views/common/PromptDialog.js
+++ b/app/views/common/PromptDialog.js
@@ -9,7 +9,7 @@ PromptDialog.prototype.setup = function (options) {
         this.valueInput.value = options.defaultValue;
     }
     if (options.title) this.title = options.title;
-    if (options.message) this.message.innerHTML = options.message;
+    if (options.message) this.message.textContent = options.message;
     if (options.value != undefined) {
         this.valueInput.value = options.value;
     }


### PR DESCRIPTION
## Problem

`options.message` is written directly into `this.message.innerHTML` without sanitization. If `options.message` can be influenced by untrusted input, arbitrary HTML/JS can execute in the renderer context.

**Severity**: `high`
**File**: `app/views/common/PromptDialog.js`

## Solution

Replace `innerHTML` with `textContent` for plain text, or sanitize using a strict allowlist sanitizer before assigning HTML.

## Changes

- `app/views/common/PromptDialog.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
