### PR TITLE
Fix renderer bootstrap and font initialization on current Electron/Linux

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,20 +1,41 @@
 const {clipboard, nativeImage, shell, ipcRenderer, webFrame} = require("electron");
+window.remote = require("@electron/remote");
+window.clipboard = clipboard;
+window.nativeImage = nativeImage;
+window.shell = shell;
+window.ipcRenderer = ipcRenderer;
+window.webFrame = webFrame;
 
-const _             = require("lodash");
-const rimraf        = require("rimraf");
-const QP            = require("q");
+window._ = require("lodash");
+window.rimraf = require("rimraf");
+window.QP = require("q");
 
-const tmp           = require("tmp");
-const path          = require("path");
-const moment        = require("moment");
-const fs            = require("fs");
-const os            = require("os");
-const jimp          = require("jimp");
-const pkgInfo       = require("./package.json");
-const QueueHandler  = require("./pencil-core/common/QueueHandler");
-const sharedUtil    = require("./pencil-core/common/shared-util");
-const dialog        = remote.dialog;
-const freehand      = require("perfect-freehand");
+window.tmp = require("tmp");
+window.path = require("path");
+window.moment = require("moment");
+window.fs = require("fs");
+window.os = require("os");
+window.jimp = require("jimp");
+window.pkgInfo = require("./package.json");
+window.QueueHandler = require("./pencil-core/common/QueueHandler");
+window.sharedUtil = require("./pencil-core/common/shared-util");
+window.dialog = window.remote.dialog;
+window.freehand = require("perfect-freehand");
+
+const _ = window._;
+const rimraf = window.rimraf;
+const QP = window.QP;
+const tmp = window.tmp;
+const path = window.path;
+const moment = window.moment;
+const fs = window.fs;
+const os = window.os;
+const jimp = window.jimp;
+const pkgInfo = window.pkgInfo;
+const QueueHandler = window.QueueHandler;
+const sharedUtil = window.sharedUtil;
+const dialog = window.dialog;
+const freehand = window.freehand;
 tmp.setGracefulCleanup();
 
 // webFrame.registerURLSchemeAsPrivileged("file");

--- a/app/pencil-core/common/FontLoader.js
+++ b/app/pencil-core/common/FontLoader.js
@@ -60,9 +60,10 @@ FontLoader.prototype.loadFonts = function (callback) {
 
     // console.log("All faces to load", allFaces);
     FontLoaderUtil.loadFontFaces(allFaces, function () {
+        var systemFaces = (FontLoader.systemRepo && FontLoader.systemRepo.faces) ? FontLoader.systemRepo.faces : [];
         var data = {
             id: Util.newUUID(),
-            faces: [].concat(FontLoader.systemRepo.faces).concat(allFaces),
+            faces: [].concat(systemFaces).concat(allFaces),
             setName: "allFaces"
         }
         ipcRenderer.once(data.id, function (event, data) {
@@ -106,8 +107,9 @@ FontLoader.prototype.getAllInstalledFonts = function () {
     var fonts = [];
     var fontNames = [];
     
-    if (FontLoader.systemRepo.fonts.length > 0) {
-        for (var font of FontLoader.systemRepo.fonts) {
+    var systemFonts = (FontLoader.systemRepo && FontLoader.systemRepo.fonts) ? FontLoader.systemRepo.fonts : [];
+    if (systemFonts.length > 0) {
+        for (var font of systemFonts) {
             var font = JSON.parse(JSON.stringify(font));
             font._type = FontRepository.TYPE_SYSTEM;
             fonts.push(font);

--- a/app/pencil-core/common/FontLoaderUtil.js
+++ b/app/pencil-core/common/FontLoaderUtil.js
@@ -27,23 +27,28 @@ FontLoaderUtil.loadFontFaces = function (allFaces, callback) {
         index ++;
         if (index >= allFaces.length) {
             if (callback) callback();
-
             return;
         }
-        var installedFace = allFaces[index];
 
+        var installedFace = allFaces[index];
         var url = FontLoaderUtil.filePathToURL(installedFace.filePath);
         var face = new FontFace(installedFace.name, "url(" + url + ")", {weight: installedFace.weight, style: installedFace.style});
         face._type = installedFace.type;
 
-        var addPromise = document.fonts.add(face);
-        addPromise.ready.then(function () {
-            var fontCSS = installedFace.style + " " + installedFace.weight + " 1em '" + installedFace.name + "'";
+        try {
+            document.fonts.add(face);
+        } catch (e) {
+        }
 
-            document.fonts.load(fontCSS).then(function () {
-                next();
-            }, next);
-        }, next);
+        face.load().then(function (loadedFace) {
+            try {
+                document.fonts.add(loadedFace);
+            } catch (e) {
+            }
+            next();
+        }).catch(function () {
+            next();
+        });
     }
 
     next();


### PR DESCRIPTION
Related to #820

## Why

On current Linux/Electron environments, Pencil can remain stuck on the splash screen because the renderer bootstrap is fragile:

- classic renderer scripts expect globals such as `fs`, `path`, and `remote`
- font initialization relies on a `document.fonts` flow that does not complete reliably
- `FontLoader` assumes `systemRepo` is already initialized

These failures prevent the application view from being mounted.

## What changed

- explicitly expose renderer bootstrap dependencies used by legacy scripts
- keep local aliases in `app.js` so the bootstrap file itself still works
- make `FontLoader` defensive when `systemRepo` is not yet available
- switch font-face loading flow to an explicit `face.load()` based sequence

## Impact

- prevents the renderer from getting stuck on the splash screen
- reduces bootstrap-time exceptions on current Linux/Electron environments
- keeps the change scoped to renderer bootstrap and font initialization